### PR TITLE
Add "Community" README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # mcScript
 mcScript libraries and examples
+
+# Community
+[beacon_decode](https://github.com/NickWaterton/beacon_decode) - Simple python script to decode module beacons and publish via MQTT.


### PR DESCRIPTION
Added beacon_decode

This link currently gives a 404, but if @NickWaterton creates the beacon_decode repository, the README will point to it in the Community section. @NickWaterton's TemperaturePublish and MQTT projects could also be made into 2 additional repositories (and linked in this README) to maintain a separation of concerns.
